### PR TITLE
Add support for different S3 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The `[DEFAULT]` section holds configurations for the entire site. Any other sect
 #### DEFAULT configuration options
 - `Domain`: This is the domain you want to configure your site on. 50mm will serve this site only if the request domain matches this.
 - `CanonicalSecure`: The 50mm server doesn't handle SSL connections. To get around this, 50mm is usually deployed behind a proxy server, like nginx. Right now 50mm doesn't look at any headers to tell if the original request was on a secure URL or not. If the `CanonicalSecure` configuration option is set to 1, 50mm assumes all requests are coming from a secure URL, and creates `https` URLs in the HTML it generates.
-- `S3Host`: The endpoint for your S3-compatible object store.
+- `S3Host`: The endpoint for your S3-compatible object store. You can safely ignore this if you are using Amazon S3.
 - `BucketRegion`: The AWS S3 region that hosts your photos bucket. If your object store doesn't have explicit regions try using "generic"
 - `BucketName`: Name of your S3 bucket.
 - `UseImgix`: If set to 1, the image URLs generated for your albums will use the Imgix image transformation service. This results in smaller image sizes and a faster web site, but Imgix is a paid service. If you turn this off (by setting the option to 0), the image URLs on your site will be AWS S3 URLs of the files you upload.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The `[DEFAULT]` section holds configurations for the entire site. Any other sect
 #### DEFAULT configuration options
 - `Domain`: This is the domain you want to configure your site on. 50mm will serve this site only if the request domain matches this.
 - `CanonicalSecure`: The 50mm server doesn't handle SSL connections. To get around this, 50mm is usually deployed behind a proxy server, like nginx. Right now 50mm doesn't look at any headers to tell if the original request was on a secure URL or not. If the `CanonicalSecure` configuration option is set to 1, 50mm assumes all requests are coming from a secure URL, and creates `https` URLs in the HTML it generates.
-- `BucketRegion`: The AWS S3 region that hosts your photos bucket.
+- `S3Host`: The endpoint for your S3-compatible object store.
+- `BucketRegion`: The AWS S3 region that hosts your photos bucket. If your object store doesn't have explicit regions try using "generic"
 - `BucketName`: Name of your S3 bucket.
 - `UseImgix`: If set to 1, the image URLs generated for your albums will use the Imgix image transformation service. This results in smaller image sizes and a faster web site, but Imgix is a paid service. If you turn this off (by setting the option to 0), the image URLs on your site will be AWS S3 URLs of the files you upload.
 - `BaseUrl`: The base URL for your Imgix account. Look at the section _Imgix setup_ below to understand what value to put here. You can skip this option if you don't use Imgix.

--- a/site.go
+++ b/site.go
@@ -19,6 +19,7 @@ type Site struct {
 	AuthUser string
 	AuthPass string
 
+	S3Host       string
 	BucketRegion string
 	BucketName   string
 
@@ -84,10 +85,15 @@ func LoadSiteFromFile(path string) (*Site, error) {
 		return nil, err
 	}
 
-	if sess, err := session.NewSession(&aws.Config{
+	sess_config := &aws.Config{
 		Region:      aws.String(s.BucketRegion),
 		Credentials: credentials.NewStaticCredentials(s.AWS_SECRET_KEY_ID, s.AWS_SECRET_KEY, ""),
-	}); err != nil {
+	}
+	if s.S3Host != "" {
+		sess_config.Endpoint = aws.String(s.S3Host)
+	}
+
+	if sess, err := session.NewSession(sess_config); err != nil {
 		return nil, err
 	} else {
 		s.awsSession = sess


### PR DESCRIPTION
Adds "S3Host" to the Site struct and pass it to the NewSession
configuration as "Endpoint". This lets the user specify an
S3-compatible object store other than AWS.

I've tested this with DreamObjects and it works.