### PR TITLE
Return nil when getting thumbnails for empty album

### DIFF
--- a/album.go
+++ b/album.go
@@ -143,8 +143,10 @@ func (a *Album) GetThumbnailPhotosForTemplate() []Renderable {
 	} else {
 		if len(photos) > 6 {
 			return photos[1:6]
-		} else {
+		} else if len(photos) > 0 {
 			return photos[1:]
+		} else {
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
GetThumbnailPhotosForTemplate assumes that the album will always have
photos in it. If the album doesn't have any photos other functions
handle it gracefully, but GetThumbnailPhotosForTemplate will crash.