### PR TITLE
Individual Photo Pages (permalinks)

### DIFF
--- a/album.go
+++ b/album.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -250,6 +251,24 @@ func (a *Album) GetAllImageKeys() ([]string, error) {
 	} else {
 		return result.keys, result.err
 	}
+}
+
+func (a *Album) ImageExists(slug string) bool {
+	svc, err := a.site.GetS3Service()
+	if err != nil {
+		return false
+	}
+
+	key := strings.Join([]string{a.BucketPrefix, slug}, "/")
+	_, err = svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(a.site.BucketName),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return false
+	}
+
+	return true
 }
 
 func (a *Album) NeedsUpdate() bool {

--- a/album.go
+++ b/album.go
@@ -50,6 +50,7 @@ func NewAlbumFromConfig(section *ini.Section, s *Site) (*Album, error) {
 		return nil, err
 	}
 
+	album.Canonicalize()
 	return album, nil
 }
 
@@ -69,6 +70,7 @@ func NewAlbum(s *Site, path string, bucketPrefix string, authUser string, authPa
 		return nil, err
 	}
 
+	album.Canonicalize()
 	return album, nil
 }
 
@@ -81,6 +83,12 @@ func (a *Album) IsValid() error {
 		return errors.New("An album that requires authentication can't be shown in the index. If you need authentication please add it to the site.")
 	}
 	return nil
+}
+
+func (a *Album) Canonicalize() {
+	if a.Path[len(a.Path)-1] != '/' {
+		a.Path = a.Path + "/"
+	}
 }
 
 func (a *Album) HasOwnAuth() bool {

--- a/main.go
+++ b/main.go
@@ -118,21 +118,18 @@ func siteHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if album, err := site.GetAlbumForPath(path); err != nil {
-			// If the path doesn't have a / at it's end, try to see if we can find an album after adding the /
-			if path[len(path)-1] != '/' {
-				if _, err := site.GetAlbumForPath(path + "/"); err == nil {
-					// If we did find it, redirect user to there
-					http.Redirect(w, r, path+"/", http.StatusMovedPermanently)
-					return
-				}
-			}
+		album, err := site.GetAlbumForPath(path)
+		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(err.Error()))
 			return
-		} else {
-			handleAlbumPage(album, w, r)
 		}
+		// Redirect to canonical album page (with trailing slash) if necessary
+		if path[len(path)-1] != '/' {
+			http.Redirect(w, r, path+"/", http.StatusMovedPermanently)
+			return
+		}
+		handleAlbumPage(album, w, r)
 	}
 }
 

--- a/photo.go
+++ b/photo.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"net/url"
-	"time"
 )
 
 type ImgixPhoto struct {
@@ -21,8 +23,14 @@ type S3Photo struct {
 }
 
 type Renderable interface {
+	Slug() string
 	GetPhotoForWidth(int) string
 	GetThumbnailForWidthAndHeight(int, int) string
+}
+
+func (p *ImgixPhoto) Slug() string {
+	parts := strings.Split(p.Key, "/")
+	return parts[len(parts)-1]
 }
 
 func (p *ImgixPhoto) GetPhotoForWidth(w int) string {
@@ -57,6 +65,11 @@ func (p *ImgixPhoto) GetThumbnailForWidthAndHeight(w, h int) string {
 	return fullUrl.String()
 }
 
+func (p *S3Photo) Slug() string {
+	parts := strings.Split(p.Key, "/")
+	return parts[len(parts)-1]
+}
+
 func (p *S3Photo) GetPhotoForWidth(w int) string {
 	req, _ := s3.New(p.awsSession).GetObjectRequest(&s3.GetObjectInput{
 		Bucket: aws.String(p.BucketName),
@@ -80,6 +93,10 @@ func (p *S3Photo) GetThumbnailForWidthAndHeight(w, h int) string {
 Used when we can't get the photo required, and have to return something, for example in methods used by templates
 */
 type ErrorPhoto struct {
+}
+
+func (p *ErrorPhoto) Slug() string {
+	return ""
 }
 
 func (p *ErrorPhoto) GetPhotoForWidth(w int) string {

--- a/site.go
+++ b/site.go
@@ -195,6 +195,9 @@ func (s *Site) GetImgixPhoto(key string) *ImgixPhoto {
 }
 
 func (s *Site) GetAlbumForPath(path string) (*Album, error) {
+	if path[len(path)-1] != '/' {
+		path = path + "/"
+	}
 	for _, album := range s.Albums {
 		if album.Path == path {
 			return album, nil

--- a/templates/album.html
+++ b/templates/album.html
@@ -30,11 +30,13 @@
                     <ul class="images">
                         {{range $index, $photo := .Photos}}
                         <li>
-                            {{if lt $index $.NumImagesToLoadAtStart}}
-                            <img src="{{$photo.GetPhotoForWidth 800}}">
-                            {{else}}
-                            <img class="lazy" src="/static/placeholder.png" data-echo="{{$photo.GetPhotoForWidth 800}}">
-                            {{end}}
+                            <a href="{{$.CanonicalUrl}}{{$photo.Slug}}">
+                                {{if lt $index $.NumImagesToLoadAtStart}}
+                                <img src="{{$photo.GetPhotoForWidth 800}}">
+                                {{else}}
+                                <img class="lazy" src="/static/placeholder.png" data-echo="{{$photo.GetPhotoForWidth 800}}">
+                                {{end}}
+                            </a>
                         </li>
                         {{end}}
                     </ul>

--- a/templates/photo.html
+++ b/templates/photo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.MetaTitle}} - {{.Slug}}</title>
+
+    <link rel="stylesheet" href="/static/base.css">
+    <link rel="stylesheet" href="/static/album.css">
+
+    <meta name="viewport" content="width=device-width">
+    <meta property="og:url" content="{{.CanonicalUrl}}{{.Slug}}" />
+    <meta property="og:title" content="{{.MetaTitle}} - {{.Slug}}" />
+    <meta property="og:image" content="{{.Photo.GetPhotoForWidth 800}}" />
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>
+                <a href="{{.SiteUrl}}">{{.SiteTitle}}</a>
+                - 
+                <a href="{{.CanonicalUrl}}">{{.AlbumTitle}}</a>
+            </h1>
+        </div>
+        <div class="photo">
+            <div class="photo-header">
+                <div class="photo-title">
+                    <h2>{{.Slug}}</h2>
+                </div>
+            </div>
+            <img src="{{.Photo.GetPhotoForWidth 800}}">
+        </div>
+        <div class="right footer">
+            <p>Built using the <a href="https://github.com/agile-leaf/50mm">50mm gallery software</a> by
+                <a href="https://www.agileleaf.com">Agile Leaf</a>.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This branch adds support for individual photo pages linked off of the main album page. This lets visitors copy permalinks to individual photos that they can share. If this is a feature you want in 50mm, let me know if there are any adjustments/refinements/changes you'd like to see!