### PR TITLE
Customizable album ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,57 @@ The app caches image keys for 1 hour in memory. If you want to clear that cache,
 
 The frontend uses [echo](https://github.com/toddmotto/echo) to lazy load images that are not in view. It also unloads images that scroll out of the view. This was done because we usually have albums with tons of images, and having them all loaded at once would hog memory.
 
+## Customize album ordering
+
+Sometimes the ordering of your photos matters - you want to images in a certain order and you  don't want to rename all your photos to get that ordering.
+
+In order to customize your album ordering in 50mm you'll have to build and upload a yaml file in to the corresponding bucket with the name `ordering.yaml`. The file has three main sections (each of which is optional), some basic examples:
+
+```yaml
+cover: PA036337.jpg
+thumbnails:
+  - PA036278.jpg
+  - PA036279.jpg
+  - PA036280.jpg
+  - PA036281.jpg
+  - PA036282.jpg
+ordering:
+  - PA036278.jpg
+  - PA036282.jpg
+  - PA015843.jpg
+  - PA015848.jpg
+  - PA015852.jpg
+  - PA015853.jpg
+  - PA015854.jpg
+  - PA015856.jpg
+```
+```yaml
+ordering:
+  - PA036278.jpg
+  - PA036282.jpg
+  - PA015843.jpg
+  - PA015848.jpg
+  - PA015852.jpg
+  - PA015853.jpg
+  - PA015854.jpg
+  - PA015856.jpg
+```
+```yaml
+thumbnails:
+  - PA036278.jpg
+  - PA036279.jpg
+ordering:
+  - PA036278.jpg
+  - PA036282.jpg
+  - PA015843.jpg
+  - PA015848.jpg
+```
+The section names are pretty self-explanatory, each element in the list should correspond to an image key in the corresponding bucket. A few important behaviours:
+
+1. 50mm processes the filenames **in order**. Filenames that exist in the actual bucket but not in the `thumbnails` or `ordering` sections causes the omitted filenames to appear later in the album (i.e: the ordering is a sort of "put these images first"). As an example, if your album has 50 images and your `ordering` section has specified two filenames, those files are plucked out of their spots in the bucket ordering and placed at the start of the album.
+1. If a filename is specified in the yaml file but does not exist in the bucket, we ignore that entry.
+1. Malformed `yaml` files are warned about but ultimately ignored.
+
 ## Final thoughts
 50mm was created because of a frustration we felt. As amateur photographers, we take lots of photographs, and didn't find an easy solution to share those photos with our friends and family. 50mm is our answer to that frustration.
 

--- a/album.go
+++ b/album.go
@@ -294,7 +294,8 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 
 	if albumOrderingConfig.Cover != "" {
 
-		// not the most efficient way of checking for existence, but it's one off.
+		// not the most efficient way of checking for existence, but it's one-off so not worth
+		// building a map/set.
 		var coverKeyInBucket = false
 		for _, bucketKey := range cleanImageKeys {
 			if strings.TrimLeft(bucketKey, "/") == strings.TrimLeft(albumOrderingConfig.Cover, "/") {
@@ -308,10 +309,18 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 		} else {
 			fmt.Printf("\ncover photo specified in ordering file not found in bucket, check %s exists. "+
 				"Falling back to first photo", albumOrderingConfig.Cover)
-			albumOrdering.Cover = a.site.GetPhotoForKey(cleanImageKeys[0])
+			if len(cleanImageKeys) > 0 {
+				albumOrdering.Cover = a.site.GetPhotoForKey(cleanImageKeys[0])
+			} else {
+				albumOrdering.Cover = a.site.GetPhotoForKey("")
+			}
 		}
 	} else {
-		albumOrdering.Cover = a.site.GetPhotoForKey(cleanImageKeys[0])
+		if len(cleanImageKeys) > 0 {
+			albumOrdering.Cover = a.site.GetPhotoForKey(cleanImageKeys[0])
+		} else {
+			albumOrdering.Cover = a.site.GetPhotoForKey("")
+		}
 	}
 
 	//thumbnails - there is a bit of duplicate code here, but it was clearer to do it

--- a/album.go
+++ b/album.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"math"
 )
 
 const CACHE_INTERVAL = 1 * time.Hour
@@ -328,20 +329,13 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 	var thumbKeys []string
 	if len(albumOrderingConfig.Thumbnails) > 0 {
 		thumbKeys = mergeList(cleanImageKeys, albumOrderingConfig.Thumbnails, a.Path)
-		if len(thumbKeys) > 5 {
-			thumbKeys = thumbKeys[0:5]
-		} else if len(thumbKeys) > 0 {
-			thumbKeys = thumbKeys[0:]
-		}
+		numUsableThumbKeys := int(math.Min(5, float64(len(thumbKeys))))
+		thumbKeys = thumbKeys[0:numUsableThumbKeys]
 	} else {
 		//take care of the offset here (i.e: cover is index 0 if we're not using the config)
-		thumbKeys = make([]string, len(cleanImageKeys))
-		copy(thumbKeys, cleanImageKeys)
-		if len(thumbKeys) > 6 {
-			thumbKeys = thumbKeys[1:6]
-		} else if len(thumbKeys) > 1 {
-			thumbKeys = thumbKeys[1:]
-		}
+		numUsableThumbKeys := int(math.Min(5, float64(len(cleanImageKeys))))
+		thumbKeys = make([]string, numUsableThumbKeys)
+		copy(thumbKeys, cleanImageKeys[1:numUsableThumbKeys+1])
 	}
 
 	for _, v := range thumbKeys {

--- a/album.go
+++ b/album.go
@@ -540,7 +540,6 @@ func (a *Album) ImageExists(slug string) bool {
 		Bucket: aws.String(a.site.BucketName),
 		Key:    aws.String(key),
 	})
-
 	if err != nil {
 		return false
 	}

--- a/album.go
+++ b/album.go
@@ -255,7 +255,7 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 	if err != nil {
 		if aerr, ok := err.(awserr.RequestFailure); ok {
 			if aerr.StatusCode() != 404 {
-				//regular 404's add too much noise, we couldn't find the file we shouldn't say anything.
+				//regular 404's add too much noise, we shouldn't say anything. Other errors should be displayed.
 				fmt.Printf("\nUnable to pick up album ordering for album %s from S3, Error: %s", a.Path, err.Error())
 			}
 		}

--- a/album.go
+++ b/album.go
@@ -156,14 +156,14 @@ func mergeList(bucketKeys []string, configKeys []string) []string {
 	var mergedKeys []string
 
 	//set up map for faster searching of set existence in the config keys
-	configMembership := make(map[string]bool)
-	for _, v := range configKeys {
-		configMembership[strings.TrimLeft(v, "/")] = true
+	bucketMembership := make(map[string]bool)
+	for _, v := range bucketKeys {
+		bucketMembership[strings.TrimLeft(v, "/")] = true
 	}
 
 	for _, configKey := range configKeys {
 		// keys in the config come first, silently drop non-existents
-		if configMembership[strings.TrimLeft(configKey, "/")] {
+		if bucketMembership[strings.TrimLeft(configKey, "/")] {
 			mergedKeys = append(mergedKeys, configKey)
 		}
 	}

--- a/album.go
+++ b/album.go
@@ -152,7 +152,7 @@ func (a *Album) GetCanonicalUrl() *url.URL {
 	return u
 }
 
-func mergeList(bucketKeys []string, configKeys []string) []string {
+func mergeList(bucketKeys []string, configKeys []string, album_name string) []string {
 	var mergedKeys []string
 
 	//set up map for faster searching of set existence in the config keys
@@ -165,6 +165,8 @@ func mergeList(bucketKeys []string, configKeys []string) []string {
 		// keys in the config come first, silently drop non-existents
 		if bucketMembership[strings.TrimLeft(configKey, "/")] {
 			mergedKeys = append(mergedKeys, configKey)
+		} else {
+			fmt.Printf("\nCould not find ordering-specified image %s in album %s", configKey, album_name)
 		}
 	}
 
@@ -316,7 +318,7 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 	//this way rather than to reduce code and be opaque
 	var thumbKeys []string
 	if len(albumOrderingConfiguration.Thumbnails) > 0 {
-		thumbKeys = mergeList(cleanImageKeys, albumOrderingConfiguration.Thumbnails)
+		thumbKeys = mergeList(cleanImageKeys, albumOrderingConfiguration.Thumbnails, a.Path)
 		if len(thumbKeys) > 5 {
 			thumbKeys = thumbKeys[0:5]
 		} else if len(thumbKeys) > 0 {
@@ -338,7 +340,7 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 	}
 
 	//the actual album ordering
-	mergedOrdering := mergeList(cleanImageKeys, albumOrderingConfiguration.Ordering)
+	mergedOrdering := mergeList(cleanImageKeys, albumOrderingConfiguration.Ordering, a.Path)
 	for _, v := range mergedOrdering {
 		albumOrdering.Ordering = append(albumOrdering.Ordering, a.site.GetPhotoForKey(v))
 	}

--- a/album.go
+++ b/album.go
@@ -64,7 +64,7 @@ type GetFromKeyCacheResult struct {
 	err  error
 }
 
-type GetFromOrderingCacheResult struct {
+type GetFromOrderingConfigCacheResult struct {
 	albumOrderingConfig AlbumOrderingConfig
 	err                 error
 }
@@ -474,10 +474,10 @@ func (a *Album) GetAlbumOrderingConfigFromS3AndPreprocess() (AlbumOrderingConfig
 //note that this also caches negative values, i.e: adding a ordering file may take an hour
 //to be rechecked.
 func (a *Album) GetAlbumOrderingConfig() (AlbumOrderingConfig, error) {
-	c := make(chan *GetFromOrderingCacheResult)
+	c := make(chan *GetFromOrderingConfigCacheResult)
 	go func() {
 		if a.OrderingCache.Load() != nil {
-			c <- &GetFromOrderingCacheResult{a.OrderingCache.Load().(AlbumOrderingConfig), nil}
+			c <- &GetFromOrderingConfigCacheResult{a.OrderingCache.Load().(AlbumOrderingConfig), nil}
 
 			a.AlbumAlbumOrderingConfigUpdateMutex.Lock()
 			if a.NeedsOrderingCacheUpdate() {
@@ -504,7 +504,7 @@ func (a *Album) GetAlbumOrderingConfig() (AlbumOrderingConfig, error) {
 				a.LastAlbumOrderingConfigCacheUpdate = time.Now()
 			}
 
-			c <- &GetFromOrderingCacheResult{albumOrdering, err}
+			c <- &GetFromOrderingConfigCacheResult{albumOrdering, err}
 
 			a.AlbumAlbumOrderingConfigUpdateMutex.Unlock()
 		}

--- a/album.go
+++ b/album.go
@@ -301,21 +301,25 @@ func (a *Album) GetOrderedPhotos() (AlbumOrdering, error) {
 		albumOrdering.Cover = a.site.GetPhotoForKey(cleanImageKeys[0])
 	}
 
-	//TODO we're stubbing here, just to get the whole infra to work again, fixme.
-	//thumbnails
+	//thumbnails - there is a bit of duplicate code here, but it was clearer to do it
+	//this way rather than to reduce code and be opaque
 	var thumbKeys []string
 	if len(albumOrderingConfiguration.Thumbnails) > 0 {
 		thumbKeys = mergeList(cleanImageKeys, albumOrderingConfiguration.Thumbnails)
+		if len(thumbKeys) > 5 {
+			thumbKeys = thumbKeys[0:5]
+		} else if len(thumbKeys) > 0 {
+			thumbKeys = thumbKeys[0:]
+		}
 	} else {
 		//take care of the offset here (i.e: cover is index 0 if we're not using the config)
-		thumbKeys = make([]string, len(cleanImageKeys)-1)
-		copy(thumbKeys, cleanImageKeys[1:])
-	}
-
-	if len(thumbKeys) > 5 {
-		thumbKeys = thumbKeys[0:5]
-	} else if len(thumbKeys) > 0 {
-		thumbKeys = thumbKeys[0:]
+		thumbKeys = make([]string, len(cleanImageKeys))
+		copy(thumbKeys, cleanImageKeys)
+		if len(thumbKeys) > 6 {
+			thumbKeys = thumbKeys[1:6]
+		} else if len(thumbKeys) > 1 {
+			thumbKeys = thumbKeys[1:]
+		}
 	}
 
 	for _, v := range thumbKeys {

--- a/main.go
+++ b/main.go
@@ -86,11 +86,12 @@ func handleAlbumPage(album *Album, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if imageUrls, err := album.GetOrderedPhotos(); err != nil {
+	if albumOrdering, err := album.GetOrderedPhotos(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	} else {
+		imageUrls := albumOrdering.Ordering
 		ctx := &AlbumPageContext{
 			&BasePageContext{
 				album.site.GetCanonicalUrl().String(),

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func handleAlbumPage(album *Album, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if imageUrls, err := album.GetAllPhotos(); err != nil {
+	if imageUrls, err := album.GetOrderedPhotos(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return


### PR DESCRIPTION
It works, ~it still needs a final passthrough/review on my part~, but just for final-state-ish awareness I opened the PR. ~I still need to look at the PR itself,~ I'm sure there are glaring mistakes.

How it works at a very very high level:
 - On album initialization look for an ordering.yml file in the bucket
 - Retrieve, parse, preprocess and then cache the ordering.yml in to an `AlbumOrderingConfig` object
 - Use the `AlbumOrderingConfig` in order to create an `AlbumOrdering` object, which gets passed around with the actual ordering of an album. This `AlbumOrdering` is a definitive definition of an Album's ordering, and is used both with and without an ordering.yml file being present

Failure modes that are handled (barring bugs or oversights):
 - No ordering.yml file (this is case is negatively cached)
 - malformed ordering.yml file (does not parse as yml) (this case is negatively cached)
 - the basic rules outlined below:

We also follow some ground rules (commented in the code in the relevant section):
```
//okay, now we're ready for processing and merging.
//some ground rules:
//0) if there is no ordering file, or an error retrieving/parsing the file, everything must work as
//   if there was never an ordering file in the first place.
//1) if an image is in the config but not in the bucket, it's silently dropped*
//2) ordering of keys in config come before ordering of keys in bucket (i.e: listed in config THEN non-listed)
//3) each section is independent and optional but has some interlinkages, (this gets difficult because you
//   don't want to pick out the same photo for both cover and thumbnail.
```
\* i say silently, but there is a message printed.

Things to do:
 - [x] Double check I didn't accidentally kill some critical error checking around the template retrieval parts.
  - [x] write up relevant section in README with examples so that people can actually use it correctly :)
- [ ] ~clean up path prefixing and url manipulation parts, I feel like I've really clobbered this, need to play around with it somewhat~
- [ ] look in to caching the `AlbumOrdering` object itself, as this alone has a bit of a cost to generate (though no network costs)

Let me know what you think.