### PR TITLE
avoid HEAD request to S3 on detail page

### DIFF
--- a/album.go
+++ b/album.go
@@ -524,21 +524,16 @@ func (a *Album) GetAlbumOrderingConfig() (AlbumOrderingConfig, error) {
 }
 
 func (a *Album) ImageExists(slug string) bool {
-	svc, err := a.site.GetS3Service()
-	if err != nil {
-		return false
+	albumOrdering, err := a.GetOrderedPhotos()
+	if err == nil {
+		// we don't really care if there was an error, we'll return false below.
+		for _, v := range albumOrdering.Ordering {
+			if strings.TrimLeft(v.Slug(), "/") == strings.TrimLeft(slug, "/") {
+				return true
+			}
+		}
 	}
-
-	key := strings.Join([]string{a.BucketPrefix, slug}, "/")
-	_, err = svc.HeadObject(&s3.HeadObjectInput{
-		Bucket: aws.String(a.site.BucketName),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return false
-	}
-
-	return true
+	return false
 }
 
 func (a *Album) NeedsKeyCacheUpdate() bool {


### PR DESCRIPTION
check if image exists against albumconfig rather than head to S3, saves making a request every time we check an image detailpage

addresses #11 